### PR TITLE
Add "Eclipse Adoptium" registry root

### DIFF
--- a/src/Classes/Adoptium/AdoptiumInstallationsDiscoverer.cs
+++ b/src/Classes/Adoptium/AdoptiumInstallationsDiscoverer.cs
@@ -18,7 +18,7 @@ namespace AJ_UpdateWatcher
     }
     static class AdoptiumInstallationsDiscoverer
     {
-        static string[] RegistryRoots = { @"SOFTWARE\AdoptOpenJDK", @"SOFTWARE\Eclipse Foundation", @"SOFTWARE\Temurin", @"SOFTWARE\Semeru" };
+        static string[] RegistryRoots = { @"SOFTWARE\AdoptOpenJDK", @"SOFTWARE\Eclipse Foundation", @"SOFTWARE\Eclipse Adoptium", @"SOFTWARE\Temurin", @"SOFTWARE\Semeru" };
 
         public static List<DiscoveredInstallation> DiscoverInstallationsByRegistryHKLM() { return DiscoverInstallationsByRegistry(RegistryHive.LocalMachine); }
         public static List<DiscoveredInstallation> DiscoverInstallationsByRegistryHKCU() { return DiscoverInstallationsByRegistry(RegistryHive.CurrentUser); }


### PR DESCRIPTION
My Adoptium installations weren't being auto-detected, so I took a look at the registry and found that the registry keys are now under `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Eclipse Adoptium` instead of "Eclipse Foundation". This PR adds that as an extra registry root.

(Note that I haven't compiled and tested this, but this PR should be trivial enough that there is no need.)