### PR TITLE
Add winget installation option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Ironically, this tool is written in C# 6 + WPF, because I am not a Java develope
 ## 📩 Download
 There's a built-in update mechanism. 
 ### 👉 [Download version 2.0.4](https://github.com/tushev/aojdk-updatewatcher/releases) 👈
+#### Or, install using winget:
+```
+winget install --id=SimonTushev.UpdateWatcherforAdoptOpenJDK -e
+```
 ### If you find this app useful, stars are appreciated :) [![GitHub stars](https://img.shields.io/github/stars/tushev/aojdk-updatewatcher.svg?style=social&label=Star&maxAge=86400)](https://GitHub.com/tushev/aojdk-updatewatcher/stargazers/)
 * ❓ [Read the wiki](https://github.com/tushev/aojdk-updatewatcher/wiki)
 


### PR DESCRIPTION
I recently submitted this app to the winget-pkgs repository, so it's now available to be installed from the winget package manager that's built into Windows. This PR would highlight this in the README so it's visible to more users. Please let me know if you release any updates and would like the winget package to be updated as well!